### PR TITLE
Rewritten uniqify() in Go

### DIFF
--- a/snippets/uniqify/uniqify.go
+++ b/snippets/uniqify/uniqify.go
@@ -2,21 +2,26 @@ package main
 
 import "fmt"
 
-func uniqify(items *[]string) {
+func uniqify(items []string) []string {
+	uniq := make([]string, 0)
 	seen := make(map[string]bool)
-	j := 0
-	for i, x := range *items {
-		if !seen[x] {
-			seen[x] = true
-			(*items)[j] = (*items)[i]
-			j++
+
+	// For the highest memory efficiency, do:
+	// seen := make(map[string]struct{})
+	// see: https://stackoverflow.com/questions/37320287/maptstruct-and-maptbool-in-golang
+
+	for _, i := range items {
+		if _, exists := seen[i]; !exists {
+			uniq = append(uniq, i)
+			seen[i] = true
 		}
 	}
-	*items = (*items)[:j]
+
+	return uniq
 }
 
 func main() {
 	items := []string{"B", "B", "E", "Q", "Q", "Q"}
-	uniqify(&items)
+	items = uniqify(items)
 	fmt.Println(items) // prints [B E Q]
 }


### PR DESCRIPTION
This is a proposal of Golang implementation of uniqify() (http://govspy.peterbe.com/#uniqify)

* It's more idiomatic to return slice than to modify it internally. Plus slice itself holds pointers so passing it by pointer is uncommon and not really needed in most cases - see https://blog.golang.org/go-slices-usage-and-internals
* I've added note about `make(map[string]struct{}` memory-tweak